### PR TITLE
Chore/update docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,8 @@ version: 2
 jobs:
   preconditions:
     working_directory: ~/Rise-Vision/widget-html
-    shell: /bin/bash --login
     docker: &BUILDIMAGE
-      - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-        command: /sbin/init
+      - image: jenkinsrise/cci-v2-transitional-widgets:0.0.4
     steps:
       - checkout
       - run: |
@@ -24,16 +22,12 @@ jobs:
 
   setup:
     working_directory: ~/Rise-Vision/widget-html
-    shell: /bin/bash --login
     docker: *BUILDIMAGE
     steps:
       - checkout
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
-      - run: nvm install 6.9.1 && nvm alias default 6.9.1
-      - run: npm install -g gulp bower casperjs
       - run: npm install
-      - run: npm run update-webdriver
       - run: bower install
       - save_cache:
           key: node-cache-{{ checksum "package.json" }}
@@ -58,26 +52,8 @@ jobs:
           paths:
             - gcloud
 
-  aws-setup:
-    docker: *BUILDIMAGE
-    steps:
-      - restore_cache:
-          key: aws-cache2
-      - run: |
-          if [[ ! -d /home/ubuntu/aws ]]
-          then
-            sudo apt-get update
-            sudo apt-get install python-dev
-            curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip" && unzip awscli-bundle.zip && sudo ./awscli-bundle/install -i /home/ubuntu/aws
-          fi
-      - save_cache:
-          key: aws-cache2
-          paths:
-            - /home/ubuntu/aws
-
   test:
     working_directory: ~/Rise-Vision/widget-html
-    shell: /bin/bash --login
     docker: *BUILDIMAGE
     steps:
       - checkout
@@ -85,20 +61,16 @@ jobs:
           at: .
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
-      # latest stable chrome
-      - run: curl -L -o google-chrome-stable.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-      - run: sudo dpkg -i google-chrome-stable.deb
-      # make chrome lxc-friendly
-      - run: sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
-      # selenium server
-      - run: wget http://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar
-      - run: nohup bash -c "java -jar selenium-server-standalone-2.44.0.jar &"
-      - run: nvm install 6.9.1 && nvm alias default 6.9.1
+      # Install latest chrome
+      - run: wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+      - run: echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee -a /etc/apt/sources.list
+      - run: sudo apt-get update -qq
+      - run: sudo apt-get install -y google-chrome-stable
+      # Run tests
       - run: NODE_ENV=dev npm run test
 
   build:
     working_directory: ~/Rise-Vision/widget-html
-    shell: /bin/bash --login
     docker: *BUILDIMAGE
     steps:
       - checkout
@@ -106,7 +78,6 @@ jobs:
           at: .
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
-      - run: nvm install 6.9.1 && nvm alias default 6.9.1
       - run: |
           if [ "${CIRCLE_BRANCH}" != "master" ]; then
             NODE_ENV=test npm run build
@@ -124,14 +95,12 @@ jobs:
   stage-aws-dev:
     shell: /bin/bash --login
     environment:
-      awscli: /home/ubuntu/aws/bin/aws
+      awscli: /usr/local/bin/aws
     docker: *BUILDIMAGE
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - restore_cache:
-          key: aws-cache2
       - run: |
           STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')"
           if [ "$STAGE_ENV" != '' ]
@@ -169,14 +138,12 @@ jobs:
   stage-aws-prod:
     shell: /bin/bash --login
     environment:
-      awscli: /home/ubuntu/aws/bin/aws
+      awscli: /usr/local/bin/aws
     docker: *BUILDIMAGE
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - restore_cache:
-          key: aws-cache2
       - run: |
           STAGE_ENV="$(git log -1 --pretty=%B | grep '\[.*\]' |sed -e 's/.*\[\(.*\)\].*/\1/g')"
           if [ "$STAGE_ENV" != '' ]
@@ -214,14 +181,12 @@ jobs:
   deploy-aws-stable:
     shell: /bin/bash --login
     environment:
-      awscli: /home/ubuntu/aws/bin/aws
+      awscli: /usr/local/bin/aws
     docker: *BUILDIMAGE
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - restore_cache:
-          key: aws-cache2
       - run: echo Deploying version $(grep version package.json |grep -o '[0-9.]*') to $BUCKET_NAME
       - run: $awscli s3 ls s3://$BUCKET_NAME || ($awscli s3 mb s3://$BUCKET_NAME && $awscli s3api put-bucket-acl --bucket $BUCKET_NAME --grant-read 'uri="http://acs.amazonaws.com/groups/global/AllUsers"')
       - run: $awscli s3 sync ./dist s3://$BUCKET_NAME/$(grep version package.json |grep -o '[0-9.]*')/dist --delete --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
@@ -241,7 +206,6 @@ jobs:
       - run: gsutil acl -r ch -u AllUsers:R gs://widgets.risevision.com/$BUCKET_NAME/$(grep version package.json |grep -o '[0-9.]*')/dist
 
   generate-artifacts:
-    shell: /bin/bash --login
     docker: *BUILDIMAGE
     steps:
       - checkout
@@ -259,9 +223,6 @@ workflows:
       - setup:
           requires:
             - preconditions
-      - aws-setup:
-          requires:
-            - preconditions
       - gcloud-setup:
           requires:
             - preconditions
@@ -274,7 +235,6 @@ workflows:
       - stage-aws-dev:
           requires:
             - build
-            - aws-setup
           filters:
             branches:
               only:
@@ -290,7 +250,6 @@ workflows:
       - stage-aws-prod:
           requires:
             - build
-            - aws-setup
           filters:
             branches:
               only:
@@ -306,7 +265,6 @@ workflows:
       - deploy-aws-stable:
           requires:
             - build
-            - aws-setup
           filters:
             branches:
               only:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Description
+Include a summary of the change. If this is fixing a defect, ensure to link to the issue this is fixing.
+
+## Motivation and Context
+Why is this change required? What problem does it solve?
+
+## How Has This Been Tested?
+Describe in detail how you tested your changes. Include details of your testing environment and link(s) for reviewers to validate.
+
+## Release Plan:
+- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
+- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
+
+#### Release Checklist Items Skipped?
+If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why

--- a/bower.json
+++ b/bower.json
@@ -51,6 +51,7 @@
     "bootstrap-form-components": "8c6281fccce4d704ca980ba37adeb48b200ce5f3",
     "bootstrap-sass-official": "3.2.0",
     "component-storage-selector": "4a525a6fe343d8657789c9934c135f137b3a86f3",
+    "font-awesome": "~4.7.0",
     "rv-common-i18n": "96a3a78b463cc14d647aadf401f490b44f450f4d",
     "rv-common-style": "1.1.4",
     "widget-settings-ui-components": "1874acc4f959cf98c27fbd57977db6b9562b27c3",


### PR DESCRIPTION
## Description
Updated docker image for CCI build

## Motivation and Context
Current CCI docker image won't allow builds as it is. This follows previous updates of other repos as widget-video.

## How Has This Been Tested?
Manually tested using staged html settings here:
https://apps.risevision.com/editor/workspace/5f5e8a68-0e06-4095-a882-772bc787be8c?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

And the runtime component was tested also in preview and in player using this schedule:
https://apps.risevision.com/schedules/details/18d0c22f-3767-4ac3-8e5c-c47a5033e69f?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - To be released before Friday
     - No new automated tests are needed. 
     - Release plan, to be validated immediately after deployment. But there's no way to revert to previous config as it won't build. No code or dependency changes are being implemented, though.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No need to notify support. No need to update documentation
